### PR TITLE
Add Ollama base nodes and preset utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# comfyui_ollama_nodes
+# ComfyUI Ollama Nodes
+
+Набор минимальных нод для работы с локальным Ollama и управления пресетами.
+
+## Доступные ноды
+- **OllamaNodeBase** — базовый текстовый запрос к Ollama
+- **OllamaVisionNodeBase** — запрос с картинкой
+- **Ollama Save Preset** — сохранение пресета в папку `prompts/`
+- **Ollama Load Preset** — загрузка пресета из `prompts/`
+- **Ollama Model** — выпадающий список моделей из `list_models.json`
+- **Ollama Run Preset** — выполнение пресета с опциональным изображением

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,23 @@
+from .ollama_node_base import OllamaNodeBase
+from .ollama_vision_node_base import OllamaVisionNodeBase
+from .ollama_preset_nodes import OllamaSavePresetNode, OllamaLoadPresetNode
+from .ollama_model_node import OllamaModelNode
+from .ollama_run_preset_node import OllamaRunPresetNode
+
+NODE_CLASS_MAPPINGS = {
+    "OllamaNodeBase": OllamaNodeBase,
+    "OllamaVisionNodeBase": OllamaVisionNodeBase,
+    "OllamaSavePresetNode": OllamaSavePresetNode,
+    "OllamaLoadPresetNode": OllamaLoadPresetNode,
+    "OllamaModelNode": OllamaModelNode,
+    "OllamaRunPresetNode": OllamaRunPresetNode,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "OllamaNodeBase": "Ollama Base",
+    "OllamaVisionNodeBase": "Ollama Vision Base",
+    "OllamaSavePresetNode": "💾 Ollama Save Preset",
+    "OllamaLoadPresetNode": "📂 Ollama Load Preset",
+    "OllamaModelNode": "Ollama Model",
+    "OllamaRunPresetNode": "Ollama Run Preset",
+}

--- a/list_models.json
+++ b/list_models.json
@@ -1,0 +1,7 @@
+[
+  "qwen2.5vl:7b",
+  "llama2:7b",
+  "gemma:2b",
+  "phi3:medium",
+  "llava:7b"
+]

--- a/ollama_model_node.py
+++ b/ollama_model_node.py
@@ -1,0 +1,29 @@
+import json
+import os
+
+
+class OllamaModelNode:
+    CATEGORY = "Ollama"
+    NODE_TITLE = "Ollama Model"
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("model_name",)
+    FUNCTION = "select"
+
+    WRITEABLE = ["model_name"]
+    INPUT_LABELS = {"model_name": "model_name"}
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        path = os.path.join(os.path.dirname(__file__), "list_models.json")
+        models = ["< no models >"]
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, list) and data:
+                models = data
+        except Exception as e:
+            print(f"[OllamaModelNode] Can't read {path}: {e}")
+        return {"required": {"model_name": (models,)}}
+
+    def select(self, model_name: str):
+        return (model_name,)

--- a/ollama_node_base.py
+++ b/ollama_node_base.py
@@ -1,0 +1,76 @@
+# ollama_node_base.py
+
+import urllib.request
+import json
+import logging
+
+# Настраиваем логгер для этой ноды
+logger = logging.getLogger("OllamaNodeBase")
+logger.setLevel(logging.DEBUG)
+
+class OllamaNodeBase:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "ip_port":       ("STRING", {"multiline": False}),  # e.g. "localhost:11434"
+                "model_name":    ("STRING", {"multiline": False}),
+                "system_prompt": ("STRING", {"multiline": True}),
+                "user_prompt":   ("STRING", {"multiline": True}),
+            }
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("response",)
+    FUNCTION     = "call_ollama"
+    CATEGORY     = "Ollama"
+
+    def call_ollama(self, ip_port, model_name, system_prompt, user_prompt):
+        url = f"http://{ip_port}/v1/chat/completions"
+        headers = {
+            "Content-Type":  "application/json",
+        }
+        payload = {
+            "model":    model_name,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user",   "content": user_prompt}
+            ]
+        }
+        data = json.dumps(payload).encode("utf-8")
+
+        for attempt in range(1, 4):
+            logger.info(f"OllamaNodeBase: Attempt {attempt}/3")
+            logger.debug(f"OllamaNodeBase: POST {url} (payload {len(data)} bytes)")
+
+            req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+            try:
+                with urllib.request.urlopen(req) as resp:
+                    status = getattr(resp, "status", resp.getcode())
+                    logger.info(f"OllamaNodeBase: HTTP {status}")
+
+                    raw = resp.read().decode("utf-8")
+                    logger.debug(f"OllamaNodeBase: Raw response: {raw}")
+
+                    resp_json = json.loads(raw)
+                    content = resp_json["choices"][0]["message"]["content"]
+                    logger.info(f"OllamaNodeBase: Got content length={len(content)}")
+                    return (content,)
+
+            except urllib.error.HTTPError as e:
+                err = f"HTTPError {e.code}: {e.reason}"
+                logger.warning(f"OllamaNodeBase: {err} on attempt {attempt}")
+                if attempt == 3:
+                    return (f"Error: {err}",)
+
+            except Exception as e:
+                logger.warning(f"OllamaNodeBase: Exception on attempt {attempt}: {e}", exc_info=True)
+                if attempt == 3:
+                    return (f"Error: {e}",)
+
+        return ("Error: exhausted retries",)
+
+# Регистрация ноды
+NODE_CLASS_MAPPINGS = {
+    "OllamaNodeBase": OllamaNodeBase
+}

--- a/ollama_preset_nodes.py
+++ b/ollama_preset_nodes.py
@@ -1,0 +1,70 @@
+import os
+from .utils import get_presets_dir
+
+
+class OllamaSavePresetNode:
+    CATEGORY = "Ollama"
+    NODE_TITLE = "Ollama Save Preset"
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("preset_prompt",)
+    FUNCTION = "process"
+
+    WRITEABLE = ["prompt", "name", "save_preset"]
+    INPUT_LABELS = {
+        "prompt": "preset_prompt",
+        "name": "preset_name",
+        "save_preset": "save_preset",
+    }
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "prompt": ("STRING", {"multiline": True, "lines": 5, "default": ""}),
+                "name": ("STRING", {"default": ""}),
+                "save_preset": ("BOOLEAN", {"default": False, "forceInput": False}),
+            }
+        }
+
+    def process(self, prompt: str, name: str, save_preset: bool):
+        if save_preset and name.strip():
+            try:
+                path = os.path.join(get_presets_dir(), f"{name}.txt")
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(prompt)
+            except Exception as e:
+                print(f"[OllamaSavePresetNode] error saving preset: {e}")
+        return (prompt,)
+
+
+class OllamaLoadPresetNode:
+    CATEGORY = "Ollama"
+    NODE_TITLE = "Ollama Load Preset"
+    RETURN_TYPES = ("STRING", "NODE_OVERLAY")
+    RETURN_NAMES = ("preset_text", "overlay")
+    FUNCTION = "load"
+    OUTPUT_NODE = True
+
+    WRITEABLE = ["file_name"]
+    INPUT_LABELS = {"file_name": "file_name"}
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        preset_dir = get_presets_dir()
+        files = sorted(
+            f for f in os.listdir(preset_dir) if f.lower().endswith(".txt")
+        ) or ["< no .txt files >"]
+        return {"required": {"file_name": (files,)}}
+
+    def load(self, file_name: str):
+        preset_dir = get_presets_dir()
+        path = os.path.join(preset_dir, file_name)
+        text = ""
+        if os.path.isfile(path):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    text = f.read()
+            except Exception as e:
+                print(f"[OllamaLoadPresetNode] Can't read {path}: {e}")
+        overlay = {"text": text, "image": None}
+        return (text, overlay)

--- a/ollama_run_preset_node.py
+++ b/ollama_run_preset_node.py
@@ -1,0 +1,146 @@
+import os
+import json
+import urllib.request
+import urllib.error
+import io
+import base64
+import logging
+from PIL import Image
+import numpy as np
+
+from .utils import get_presets_dir
+
+logger = logging.getLogger("OllamaRunPresetNode")
+logger.setLevel(logging.DEBUG)
+
+
+def _to_pil(img):
+    if isinstance(img, Image.Image):
+        return img
+    if hasattr(img, "cpu"):
+        arr = img.cpu().detach().numpy()
+    else:
+        arr = np.array(img)
+    arr = np.squeeze(arr)
+    if np.issubdtype(arr.dtype, np.floating):
+        arr = (arr * 255).clip(0, 255).astype(np.uint8)
+    if arr.ndim == 3 and arr.shape[0] in (1, 3, 4):
+        arr = np.transpose(arr, (1, 2, 0))
+    if arr.ndim == 3:
+        ch = arr.shape[2]
+        mode = {1: "L", 3: "RGB", 4: "RGBA"}.get(ch)
+        if not mode:
+            raise TypeError(f"Unsupported channels: {ch}")
+    elif arr.ndim == 2:
+        mode = "L"
+    else:
+        raise TypeError(f"Cannot handle shape: {arr.shape}")
+    return Image.fromarray(arr, mode)
+
+
+class OllamaRunPresetNode:
+    CATEGORY = "Ollama"
+    NODE_TITLE = "Ollama Run Preset"
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("response",)
+    FUNCTION = "run"
+
+    WRITEABLE = ["preset_name", "model_name", "user_prompt"]
+    INPUT_LABELS = {
+        "preset_name": "preset_name",
+        "model_name": "model_name",
+        "user_prompt": "user_prompt",
+        "img": "img",
+    }
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        preset_dir = get_presets_dir()
+        presets = sorted(
+            f for f in os.listdir(preset_dir) if f.lower().endswith(".txt")
+        ) or ["< no .txt files >"]
+
+        model_path = os.path.join(os.path.dirname(__file__), "list_models.json")
+        models = ["< no models >"]
+        try:
+            with open(model_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, list) and data:
+                models = data
+        except Exception as e:
+            print(f"[OllamaRunPresetNode] Can't read {model_path}: {e}")
+
+        return {
+            "required": {
+                "preset_name": (presets,),
+                "model_name": (models,),
+                "user_prompt": ("STRING", {"multiline": True, "lines": 5, "default": ""}),
+                "img": ("IMAGE", {}),
+            }
+        }
+
+    def run(self, preset_name: str, model_name: str, user_prompt: str, img):
+        preset_dir = get_presets_dir()
+        path = os.path.join(preset_dir, preset_name)
+        system_prompt = ""
+        if os.path.isfile(path):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    system_prompt = f.read()
+            except Exception as e:
+                print(f"[OllamaRunPresetNode] Can't read {path}: {e}")
+
+        url = "http://localhost:11434/v1/chat/completions"
+        headers = {"Content-Type": "application/json"}
+
+        if img is not None:
+            try:
+                pil = _to_pil(img)
+            except Exception as e:
+                logger.error("Conversion to PIL failed", exc_info=True)
+                return (f"Error converting image: {e}",)
+            pil.thumbnail((512, 512))
+            buf = io.BytesIO()
+            pil.save(buf, format="JPEG", quality=75)
+            data_url = "data:image/jpeg;base64," + base64.b64encode(buf.getvalue()).decode()
+            messages = [
+                {"role": "system", "content": [{"type": "text", "text": system_prompt}]},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": user_prompt},
+                        {"type": "image_url", "image_url": {"url": data_url}},
+                    ],
+                },
+            ]
+            payload = {"model": model_name, "messages": messages, "max_tokens": 1024}
+        else:
+            payload = {
+                "model": model_name,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+            }
+
+        body = json.dumps(payload).encode("utf-8")
+
+        for attempt in range(1, 4):
+            logger.info(f"OllamaRunPresetNode: Attempt {attempt}/3")
+            req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+            try:
+                with urllib.request.urlopen(req) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    text = data["choices"][0]["message"]["content"]
+                    logger.info(f"OllamaRunPresetNode: Got content length={len(text)}")
+                    return (text,)
+            except urllib.error.HTTPError as e:
+                err = f"HTTPError {e.code}: {e.reason}"
+                logger.warning(f"OllamaRunPresetNode: {err} on attempt {attempt}")
+                if attempt == 3:
+                    return (f"Error: {err}",)
+            except Exception as e:
+                logger.warning(f"OllamaRunPresetNode: Exception on attempt {attempt}: {e}", exc_info=True)
+                if attempt == 3:
+                    return (f"Error: {e}",)
+        return ("Error: exhausted retries",)

--- a/ollama_vision_node_base.py
+++ b/ollama_vision_node_base.py
@@ -1,0 +1,114 @@
+# ollama_vision_node_base.py
+
+import urllib.request
+import urllib.error
+import json
+import io
+import base64
+import logging
+
+from PIL import Image
+import numpy as np
+
+logger = logging.getLogger("OllamaVisionNodeBase")
+logger.setLevel(logging.DEBUG)
+
+class OllamaVisionNodeBase:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "ip_port":       ("STRING", {"multiline": False}),  # e.g. "localhost:11434"
+                "model_name":    ("STRING", {"multiline": False}),
+                "system_prompt": ("STRING", {"multiline": True}),
+                "user_prompt":   ("STRING", {"multiline": True}),
+                "img":           ("IMAGE",  {}),
+            },
+            "optional": {
+                "max_tokens": ("INT", {"default": 1024}),
+            }
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("response",)
+    FUNCTION     = "call_ollama"
+    CATEGORY     = "Ollama"
+
+    @staticmethod
+    def _to_pil(img):
+        if isinstance(img, Image.Image):
+            return img
+        if hasattr(img, "cpu"):
+            arr = img.cpu().detach().numpy()
+        else:
+            arr = np.array(img)
+        arr = np.squeeze(arr)
+        if np.issubdtype(arr.dtype, np.floating):
+            arr = (arr * 255).clip(0, 255).astype(np.uint8)
+        if arr.ndim == 3 and arr.shape[0] in (1, 3, 4):
+            arr = np.transpose(arr, (1, 2, 0))
+        if arr.ndim == 3:
+            ch = arr.shape[2]
+            mode = {1:"L",3:"RGB",4:"RGBA"}.get(ch)
+            if not mode:
+                raise TypeError(f"Unsupported channels: {ch}")
+        elif arr.ndim == 2:
+            mode = "L"
+        else:
+            raise TypeError(f"Cannot handle shape: {arr.shape}")
+        return Image.fromarray(arr, mode)
+
+    def call_ollama(self, ip_port, model_name, system_prompt, user_prompt, img, max_tokens=1024):
+        try:
+            pil = self._to_pil(img)
+        except Exception as e:
+            logger.error("Conversion to PIL failed", exc_info=True)
+            return (f"Error converting image: {e}",)
+
+        pil.thumbnail((512, 512))
+        buf = io.BytesIO()
+        pil.save(buf, format="JPEG", quality=75)
+        data_url = "data:image/jpeg;base64," + base64.b64encode(buf.getvalue()).decode()
+        logger.debug(f"OllamaVisionNodeBase: data_url length={len(data_url)}")
+
+        messages = [
+            {"role": "system", "content": [{"type":"text","text":system_prompt}]},
+            {"role": "user",   "content": [
+                {"type":"text","text":user_prompt},
+                {"type":"image_url","image_url":{"url":data_url}}
+            ]}
+        ]
+        payload = {
+            "model":      model_name,
+            "messages":   messages,
+            "max_tokens": max_tokens,
+        }
+        body = json.dumps(payload).encode("utf-8")
+
+        url = f"http://{ip_port}/v1/chat/completions"
+        headers = {"Content-Type": "application/json"}
+
+        for attempt in range(1, 4):
+            logger.info(f"OllamaVisionNodeBase: Attempt {attempt}/3 (max_tokens={max_tokens})")
+            req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+            try:
+                with urllib.request.urlopen(req) as resp:
+                    j = json.loads(resp.read().decode("utf-8"))
+                    text = j["choices"][0]["message"]["content"]
+                    logger.info(f"OllamaVisionNodeBase: Got content length={len(text)}")
+                    return (text,)
+            except urllib.error.HTTPError as e:
+                err = f"HTTPError {e.code}: {e.reason}"
+                logger.warning(f"OllamaVisionNodeBase: {err} on attempt {attempt}")
+                if attempt == 3:
+                    return (f"Error: {err}",)
+            except Exception as e:
+                logger.warning(f"OllamaVisionNodeBase: Exception on attempt {attempt}: {e}", exc_info=True)
+                if attempt == 3:
+                    return (f"Error: {e}",)
+        return ("Error: exhausted retries",)
+
+# Регистрация ноды
+NODE_CLASS_MAPPINGS = {
+    "OllamaVisionNodeBase": OllamaVisionNodeBase
+}

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,9 @@
+import os
+
+
+def get_presets_dir() -> str:
+    """Return absolute path to the presets folder in ComfyUI root."""
+    base = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    presets_dir = os.path.join(base, "prompts")
+    os.makedirs(presets_dir, exist_ok=True)
+    return presets_dir


### PR DESCRIPTION
## Summary
- add base versions of `OllamaNode` and `OllamaVisionNode`
- implement preset save/load utilities
- provide a model list and node to select from it
- add node to execute presets
- document all provided nodes

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6877e0030c20832c803d6ccd3649f937