### PR TITLE
Make img optional in Run Preset node

### DIFF
--- a/ollama_run_preset_node.py
+++ b/ollama_run_preset_node.py
@@ -77,11 +77,13 @@ class OllamaRunPresetNode:
                 "preset_name": (presets,),
                 "model_name": (models,),
                 "user_prompt": ("STRING", {"multiline": True, "lines": 5, "default": ""}),
+            },
+            "optional": {
                 "img": ("IMAGE", {}),
-            }
+            },
         }
 
-    def run(self, ip_port: str, preset_name: str, model_name: str, user_prompt: str, img):
+    def run(self, ip_port: str, preset_name: str, model_name: str, user_prompt: str, img=None):
         preset_dir = get_presets_dir()
         path = os.path.join(preset_dir, preset_name)
         system_prompt = ""


### PR DESCRIPTION
## Summary
- make the `img` input optional for `OllamaRunPresetNode`

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6877f906856c832c861fdded12714ce1