### PR TITLE
Improve Ollama logging and fix parameter order

### DIFF
--- a/ollama_node_base.py
+++ b/ollama_node_base.py
@@ -61,7 +61,8 @@ class OllamaNodeBase:
                     content = resp_json["choices"][0]["message"]["content"]
                     logger.info(f"OllamaNodeBase: Got content length={len(content)}")
                     if not keep_in_memory:
-                        stop_model(ip_port)
+                        result = stop_model(ip_port, model_name)
+                        logger.info(f"OllamaNodeBase: stop_model result={result}")
                     return (content,)
 
             except urllib.error.HTTPError as e:

--- a/ollama_run_preset_node.py
+++ b/ollama_run_preset_node.py
@@ -84,7 +84,7 @@ class OllamaRunPresetNode:
             },
         }
 
-    def run(self, ip_port: str, preset_name: str, model_name: str, user_prompt: str, img=None, keep_in_memory=True):
+    def run(self, ip_port: str, preset_name: str, model_name: str, user_prompt: str, keep_in_memory=True, img=None):
         preset_dir = get_presets_dir()
         path = os.path.join(preset_dir, preset_name)
         system_prompt = ""
@@ -141,7 +141,8 @@ class OllamaRunPresetNode:
                     text = data["choices"][0]["message"]["content"]
                     logger.info(f"OllamaRunPresetNode: Got content length={len(text)}")
                     if not keep_in_memory:
-                        stop_model(ip_port)
+                        result = stop_model(ip_port, model_name)
+                        logger.info(f"OllamaRunPresetNode: stop_model result={result}")
                     return (text,)
             except urllib.error.HTTPError as e:
                 err = f"HTTPError {e.code}: {e.reason}"

--- a/ollama_vision_node_base.py
+++ b/ollama_vision_node_base.py
@@ -61,7 +61,7 @@ class OllamaVisionNodeBase:
             raise TypeError(f"Cannot handle shape: {arr.shape}")
         return Image.fromarray(arr, mode)
 
-    def call_ollama(self, ip_port, model_name, system_prompt, user_prompt, img=None, max_tokens=1024, keep_in_memory=True):
+    def call_ollama(self, ip_port, model_name, system_prompt, user_prompt, keep_in_memory=True, img=None, max_tokens=1024):
         if img is not None:
             try:
                 pil = self._to_pil(img)
@@ -112,7 +112,8 @@ class OllamaVisionNodeBase:
                     text = j["choices"][0]["message"]["content"]
                     logger.info(f"OllamaVisionNodeBase: Got content length={len(text)}")
                     if not keep_in_memory:
-                        stop_model(ip_port)
+                        result = stop_model(ip_port, model_name)
+                        logger.info(f"OllamaVisionNodeBase: stop_model result={result}")
                     return (text,)
             except urllib.error.HTTPError as e:
                 err = f"HTTPError {e.code}: {e.reason}"


### PR DESCRIPTION
## Summary
- clean up utils logging
- allow specifying model name when stopping
- fix param order for vision/preset nodes
- log unload results

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_687a38f3856c832cabbf417004cff944