### PR TITLE
Add reasoning nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 - **Ollama Load Preset** — загрузка пресета из `\ComfyUi\Ollama_presets`
 - **Ollama Model** — выпадающий список моделей из `list_models.json`
 - **Ollama Run Preset** — выполнение пресета с опциональным изображением
+- **Ollama Reasoning** — запуск reasoning моделей без картинки
+- **Reasoning Model** — выпадающий список reasoning моделей из `reasoning_model_list.json`
 
 
 ## 1. Установка Ollama

--- a/__init__.py
+++ b/__init__.py
@@ -3,6 +3,8 @@ from .ollama_vision_node_base import OllamaVisionNodeBase
 from .ollama_preset_nodes import OllamaSavePresetNode, OllamaLoadPresetNode
 from .ollama_model_node import OllamaModelNode
 from .ollama_run_preset_node import OllamaRunPresetNode
+from .ollama_reasoning_node import OllamaReasoningNode
+from .ollama_reasoning_model_node import OllamaReasoningModelNode
 
 NODE_CLASS_MAPPINGS = {
     "OllamaNodeBase": OllamaNodeBase,
@@ -11,6 +13,8 @@ NODE_CLASS_MAPPINGS = {
     "OllamaLoadPresetNode": OllamaLoadPresetNode,
     "OllamaModelNode": OllamaModelNode,
     "OllamaRunPresetNode": OllamaRunPresetNode,
+    "OllamaReasoningNode": OllamaReasoningNode,
+    "OllamaReasoningModelNode": OllamaReasoningModelNode,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -20,4 +24,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "OllamaLoadPresetNode": "📂 Ollama Load Preset",
     "OllamaModelNode": "Ollama Model",
     "OllamaRunPresetNode": "Ollama Run Preset",
+    "OllamaReasoningNode": "Ollama Reasoning",
+    "OllamaReasoningModelNode": "Reasoning Model",
 }

--- a/ollama_reasoning_model_node.py
+++ b/ollama_reasoning_model_node.py
@@ -1,0 +1,34 @@
+import json
+import os
+
+
+class OllamaReasoningModelNode:
+    CATEGORY = "OllamaComfy"
+    NODE_TITLE = "Ollama Reasoning Model"
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("model_name",)
+    FUNCTION = "select"
+
+    WRITEABLE = ["model_name"]
+    INPUT_LABELS = {"model_name": "model_name"}
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        path = os.path.join(os.path.dirname(__file__), "reasoning_model_list.json")
+        models = ["< no models >"]
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, list) and data:
+                models = data
+        except Exception as e:
+            print(f"[OllamaReasoningModelNode] Can't read {path}: {e}")
+        return {"required": {"model_name": (models,)}}
+
+    def select(self, model_name: str):
+        return (model_name,)
+
+
+NODE_CLASS_MAPPINGS = {
+    "OllamaReasoningModelNode": OllamaReasoningModelNode,
+}

--- a/ollama_reasoning_node.py
+++ b/ollama_reasoning_node.py
@@ -1,0 +1,89 @@
+import json
+import urllib.request
+import urllib.error
+import logging
+import re
+
+from .utils import pull_model, stop_model
+
+logger = logging.getLogger("OllamaReasoningNode")
+logger.setLevel(logging.DEBUG)
+
+
+class OllamaReasoningNode:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "ip_port": ("STRING", {"multiline": False}),
+                "model_name": ("STRING", {"multiline": False}),
+                "system_prompt": ("STRING", {"multiline": True}),
+                "user_prompt": ("STRING", {"multiline": True}),
+                "keep_in_memory": ("BOOLEAN", {"default": True, "forceInput": False}),
+            }
+        }
+
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("thoughts", "response")
+    FUNCTION = "run"
+    CATEGORY = "OllamaComfy"
+
+    def _parse_answer(self, text: str):
+        thoughts = ""
+        response = text
+        pattern = re.compile(
+            r"(?is)(?:thoughts?|analysis)\s*[:\-]\s*(.*?)\n(?:response|answer|final)\s*[:\-]\s*(.*)"
+        )
+        m = pattern.search(text)
+        if m:
+            thoughts = m.group(1).strip()
+            response = m.group(2).strip()
+        return thoughts, response
+
+    def run(self, ip_port, model_name, system_prompt, user_prompt, keep_in_memory=True):
+        url = f"http://{ip_port}/v1/chat/completions"
+        headers = {"Content-Type": "application/json"}
+        payload = {
+            "model": model_name,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            "keep_alive": -1 if keep_in_memory else 0,
+        }
+        data = json.dumps(payload).encode("utf-8")
+
+        pulled = False
+        for attempt in range(1, 4):
+            logger.info(f"OllamaReasoningNode: Attempt {attempt}/3")
+            req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+            try:
+                with urllib.request.urlopen(req) as resp:
+                    raw = resp.read().decode("utf-8")
+                    logger.debug(f"OllamaReasoningNode: Raw response: {raw}")
+                    j = json.loads(raw)
+                    text = j["choices"][0]["message"]["content"]
+                    logger.info(f"OllamaReasoningNode: Got content length={len(text)}")
+                    if not keep_in_memory:
+                        result = stop_model(ip_port, model_name)
+                        logger.info(f"OllamaReasoningNode: stop_model result={result}")
+                    return self._parse_answer(text)
+            except urllib.error.HTTPError as e:
+                err = f"HTTPError {e.code}: {e.reason}"
+                logger.warning(f"OllamaReasoningNode: {err} on attempt {attempt}")
+                if e.code == 404 and not pulled:
+                    logger.info("OllamaReasoningNode: model not found, pulling...")
+                    pulled = pull_model(ip_port, model_name)
+                    continue
+                if attempt == 3:
+                    return ("", f"Error: {err}")
+            except Exception as e:
+                logger.warning(f"OllamaReasoningNode: Exception on attempt {attempt}: {e}", exc_info=True)
+                if attempt == 3:
+                    return ("", f"Error: {e}")
+        return ("", "Error: exhausted retries")
+
+
+NODE_CLASS_MAPPINGS = {
+    "OllamaReasoningNode": OllamaReasoningNode,
+}

--- a/reasoning_model_list.json
+++ b/reasoning_model_list.json
@@ -1,0 +1,5 @@
+[
+  "phi4-mini-reasoning:3.8b",
+  "deepseek-r1:1.5b",
+  "deepseek-r1:8b"
+]


### PR DESCRIPTION
## Summary
- add `OllamaReasoningNode` for reasoning models
- add `OllamaReasoningModelNode` and `reasoning_model_list.json`
- register new nodes
- document new reasoning nodes in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_687b49cd77ac832c905fed0baaaf4542